### PR TITLE
Fixing two problems with chase: An extra LED would be used.  The LED aft...

### DIFF
--- a/pixelpi.py
+++ b/pixelpi.py
@@ -338,11 +338,11 @@ def chase():
     pixel_index = 0
     while True:
         for current_color[:] in RAINBOW:
-	    for pixel_index in range(args.num_leds+1):
+	    for pixel_index in range(args.num_leds):
                 pixel_output[((pixel_index-2)*PIXEL_SIZE):] = filter_pixel(current_color[:],0.2) 
                 pixel_output[((pixel_index-1)*PIXEL_SIZE):] = filter_pixel(current_color[:],0.4) 
                 pixel_output[((pixel_index)*PIXEL_SIZE):] = filter_pixel(current_color[:], 1)
-		pixel_output += '\x00'* ((args.num_leds+1-pixel_index)*PIXEL_SIZE)
+		pixel_output += '\x00'* ((args.num_leds-1-pixel_index)*PIXEL_SIZE)
                 spidev.write(pixel_output)
                 spidev.flush()
                 time.sleep((args.refresh_rate)/1000.0)


### PR DESCRIPTION
...er the amount specified is turned off each time.  Not needed.

The problem could be seen when setting a few leds on:

sudo python pixelpi.py chase --chip WS2801 --num_leds 10 --refresh_rate 100

and then running chase with less pixels/leds

sudo python pixelpi.py chase --chip WS2801 --num_leds 6 --refresh_rate 100

What should happen, and does with the above fix, is that only the first 6 LEDs are used for the chase and the rest remain on.
